### PR TITLE
Update BSImagePickerViewController.swift

### DIFF
--- a/Pod/Classes/Controller/BSImagePickerViewController.swift
+++ b/Pod/Classes/Controller/BSImagePickerViewController.swift
@@ -47,7 +47,10 @@ open class BSImagePickerViewController : UINavigationController {
      Default selections
      */
     private var defaultSelections: PHFetchResult<PHAsset>?
-    
+     /**
+     Default selections [asset.localIdentifier]
+     */
+    open var defaultSelectedAssetIDs: [String]?
     /**
      Fetch results.
      */
@@ -68,6 +71,12 @@ open class BSImagePickerViewController : UINavigationController {
     static let bundle: Bundle = Bundle(path: Bundle(for: PhotosViewController.self).path(forResource: "BSImagePicker", ofType: "bundle")!)!
     
     lazy var photosViewController: PhotosViewController = {
+        
+        if self.defaultSelectedAssetIDs != nil {
+            let selectedAssets     = PHAsset.fetchAssets(withLocalIdentifiers: self.defaultSelectedAssetIDs!, options: nil)
+            self.defaultSelections = selectedAssets
+        }
+        
         let vc = PhotosViewController(fetchResults: self.fetchResults,
                                       defaultSelections: self.defaultSelections,
                                       settings: self.settings)


### PR DESCRIPTION
For "default selection".  Using asset's localIdentifier instead of  PHFetchResult<PHAsset>. 
(i have no idea why  PHFetchResult<PHAsset>? cannot be used, it would cause an error when compiling)

if you have a better way to fix it, pls let me know. thanks. 
